### PR TITLE
Fix remote URL for download and added download-channel selection feature

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -54,14 +54,14 @@ function getClientOption() {
 }
 function startLanguageClient(
   serverOptions: ServerOptions,
-  clientOptions: LanguageClientOptions
+  clientOptions: LanguageClientOptions,
 ) {
   // Create the language client and start the client.
   client = new LanguageClient(
     "mimium-language-server",
     "mimium language server",
     serverOptions,
-    clientOptions
+    clientOptions,
   );
 
   client.start();
@@ -87,27 +87,27 @@ export function dispose() {
  */
 export function activate(context: vscode.ExtensionContext): void {
   traceOutputChannel = vscode.window.createOutputChannel(
-    "Mimium Language Server trace"
+    "Mimium Language Server trace",
   );
   startLanguageClient(getServerOption(), getClientOption());
 
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "extension.mimium.restartServer",
-      restartLanguageClient
-    )
+      restartLanguageClient,
+    ),
   );
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "extension.mimiumdownloadbinary",
-      downloadBinary
-    )
+      downloadBinary,
+    ),
   );
 
   context.subscriptions.push(
     vscode.commands.registerCommand("extension.mimiumrun", () => {
       runMimium(terminal);
-    })
+    }),
   );
   checkIfNewerVersionAvailable();
 }

--- a/client/src/installer.ts
+++ b/client/src/installer.ts
@@ -4,7 +4,7 @@
 import * as vscode from "vscode";
 
 // node
-import { platform } from "os";
+import { arch, platform } from "os";
 import * as fs from "fs";
 import * as path from "path";
 import { spawnSync } from "child_process";
@@ -14,16 +14,187 @@ import { Version, parseVersion } from "./utils";
 
 const getConfig = () => vscode.workspace.getConfiguration("mimium");
 
+const MIMIUM_RELEASES_PAGE =
+  "https://github.com/mimium-org/mimium-rs/releases";
+const MIMIUM_EXPANDED_ASSETS_PAGE =
+  "https://github.com/mimium-org/mimium-rs/releases/expanded_assets";
+
+type ReleaseChannel = "stable" | "alpha";
+
+type GitHubReleaseAsset = {
+  name: string;
+  browser_download_url: string;
+};
+
+type GitHubRelease = {
+  tag_name: string;
+  draft: boolean;
+  prerelease: boolean;
+  published_at: string;
+  assets: GitHubReleaseAsset[];
+};
+
+type ReleaseDownload = {
+  release: GitHubRelease;
+  asset: GitHubReleaseAsset;
+};
+
+const getReleaseChannel = (): ReleaseChannel => {
+  return getConfig().get<ReleaseChannel>("releaseChannel", "stable");
+};
+
+const fetchText = async (
+  url: string,
+  headers: Record<string, string>,
+): Promise<string> => {
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(
+      `mimium: failed to fetch release metadata (${response.status} ${response.statusText})`,
+    );
+  }
+  return response.text();
+};
+
+const parseReleasesFromHtml = (html: string): GitHubRelease[] => {
+  const releaseMap = new Map<string, GitHubRelease>();
+  const tagPattern = /\/releases\/tag\/([^"?#]+)/g;
+  let matched: RegExpExecArray | null;
+
+  while ((matched = tagPattern.exec(html)) !== null) {
+    const tagName = decodeURIComponent(matched[1]);
+    if (!releaseMap.has(tagName)) {
+      releaseMap.set(tagName, {
+        tag_name: tagName,
+        draft: false,
+        prerelease: isPrereleaseTag(tagName),
+        published_at: "",
+        assets: [],
+      });
+    }
+  }
+
+  return Array.from(releaseMap.values());
+};
+
+const parseAssetsFromHtml = (html: string): GitHubReleaseAsset[] => {
+  const assetPattern = /href="([^"]*\/releases\/download\/[^"?#]+\.zip)"/g;
+  const assetMap = new Map<string, GitHubReleaseAsset>();
+  let matched: RegExpExecArray | null;
+
+  while ((matched = assetPattern.exec(html)) !== null) {
+    const href = matched[1].replace(/&amp;/g, "&");
+    const browserDownloadUrl = href.startsWith("http")
+      ? href
+      : `https://github.com${href}`;
+    const name = browserDownloadUrl.split("/").pop();
+    if (!name || name.endsWith(".zip.sha256")) {
+      continue;
+    }
+    assetMap.set(name, {
+      name,
+      browser_download_url: browserDownloadUrl,
+    });
+  }
+
+  return Array.from(assetMap.values());
+};
+
+const fetchReleases = async (): Promise<GitHubRelease[]> => {
+  const headers = {
+    Accept: "text/html,application/xhtml+xml",
+    "User-Agent": "mimium-language-vscode",
+  };
+  const releasesPage = await fetchText(MIMIUM_RELEASES_PAGE, headers);
+  const releases = parseReleasesFromHtml(releasesPage);
+
+  for (const release of releases) {
+    const assetsPage = await fetchText(
+      `${MIMIUM_EXPANDED_ASSETS_PAGE}/${encodeURIComponent(release.tag_name)}`,
+      headers,
+    );
+    release.assets = parseAssetsFromHtml(assetsPage);
+  }
+
+  return releases;
+};
+
+const isPrereleaseTag = (tagName: string): boolean => {
+  return /-(alpha|beta|rc)(?:[.-]|$)/i.test(tagName);
+};
+
+const getTargetTriples = (): string[] => {
+  switch (platform()) {
+    case "win32":
+      return ["x86_64-pc-windows-msvc"];
+    case "darwin":
+      return arch() === "x64"
+        ? ["x86_64-apple-darwin"]
+        : ["aarch64-apple-darwin"];
+    case "linux":
+      return ["x86_64-unknown-linux-gnu"];
+    default:
+      vscode.window.showErrorMessage(
+        `mimium: binary download currently only \
+            available for macOS, Windows & Linux (Ubuntu)`,
+      );
+      return [];
+  }
+};
+
+const findMatchingAsset = (
+  assets: GitHubReleaseAsset[],
+  targetTriples: string[],
+): GitHubReleaseAsset | undefined => {
+  return assets.find((asset) => {
+    return (
+      asset.name.endsWith(".zip") &&
+      !asset.name.endsWith(".zip.sha256") &&
+      targetTriples.some((triple) => asset.name.includes(triple))
+    );
+  });
+};
+
+const resolveLatestRelease = async (
+  channel: ReleaseChannel,
+): Promise<ReleaseDownload | null> => {
+  const targetTriples = getTargetTriples();
+  if (targetTriples.length === 0) {
+    return null;
+  }
+
+  const releases = await fetchReleases();
+  const matchingRelease = releases
+    .filter((release) => {
+      if (release.draft) {
+        return false;
+      }
+      if (channel === "stable") {
+        return !release.prerelease && !isPrereleaseTag(release.tag_name);
+      }
+      return true;
+    })
+    .map((release) => ({
+      release,
+      asset: findMatchingAsset(release.assets, targetTriples),
+    }))
+    .find(
+      (
+        candidate,
+      ): candidate is { release: GitHubRelease; asset: GitHubReleaseAsset } => {
+        return candidate.asset !== undefined;
+      },
+    );
+
+  return matchingRelease ?? null;
+};
+
 const getLatestVersionOfMimium = async (): Promise<Version> => {
-  const endpoint = `https://api.github.com/repos/tomoyanonymous/mimium-rs/releases`;
-  // const endpoint = `https://api.github.com/repos/tomoyanonymous/mimium-rs/releases?client_id=${client_id}?client_secret=${client_secret}`;
-  const tagData: [any] = await fetch(endpoint).then((res) => res.json());
-  const sorted_responses = tagData.sort(
-    (a, b) =>
-      new Date(b.published_at).getTime() - new Date(a.published_at).getTime()
-  );
-  const mimiumVersion: string = sorted_responses[0].tag_name;
-  return parseVersion(mimiumVersion);
+  const releaseDownload = await resolveLatestRelease(getReleaseChannel());
+  if (releaseDownload === null) {
+    throw new Error("mimium: no downloadable release found for this platform");
+  }
+  return parseVersion(releaseDownload.release.tag_name);
 };
 
 const getCurrentVersionOfMimium = (): Version | null => {
@@ -45,25 +216,35 @@ const getDefaultDownloadPath = (): string => {
     return "";
   }
 };
-const getDownloadfileName = (): string => {
-  switch (platform()) {
-    case "win32":
-      return `mimium-bintools-x86_64-pc-windows-msvc.zip`;
-    case "darwin":
-      return `mimium-bintools-aarch64-apple-darwin.zip`;
-    case "linux":
-      return `mimium-bintools-x86_64-unknown-linux-gnu.zip`;
-    default:
-      vscode.window.showErrorMessage(
-        `mimium: binary download currently only \
-            available for macOS, Windows & Linux (Ubuntu)`
-      );
-      return "~/";
+
+const moveExtractedEntries = (
+  extractRoot: string,
+  destinationDir: string,
+): void => {
+  const extractedEntries = fs.readdirSync(extractRoot);
+  const sourceDir =
+    extractedEntries.length === 1 &&
+    fs.statSync(path.join(extractRoot, extractedEntries[0])).isDirectory()
+      ? path.join(extractRoot, extractedEntries[0])
+      : extractRoot;
+
+  for (const entry of fs.readdirSync(sourceDir)) {
+    const sourcePath = path.join(sourceDir, entry);
+    const destinationPath = path.join(destinationDir, entry);
+    fs.rmSync(destinationPath, { recursive: true, force: true });
+    fs.renameSync(sourcePath, destinationPath);
   }
 };
 
 export const checkIfNewerVersionAvailable = async () => {
-  const latest = await getLatestVersionOfMimium();
+  let latest: Version;
+  try {
+    latest = await getLatestVersionOfMimium();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    vscode.window.showErrorMessage(message);
+    return;
+  }
   const current = getCurrentVersionOfMimium();
   const shouldGet: boolean = current === null ? true : latest.isNewer(current);
   if (shouldGet) {
@@ -90,33 +271,55 @@ export const checkIfNewerVersionAvailable = async () => {
 };
 
 export const downloadBinary = async () => {
-  const mimiumVersionRaw = await getLatestVersionOfMimium();
-  const mimiumVersion: string = mimiumVersionRaw.text;
+  let releaseDownload: ReleaseDownload | null;
+  try {
+    releaseDownload = await resolveLatestRelease(getReleaseChannel());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    vscode.window.showErrorMessage(message);
+    return;
+  }
 
-  if (!mimiumVersion) {
+  if (!releaseDownload) {
     vscode.window.showErrorMessage(
-      "mimium: error fetching latest release tag name"
+      "mimium: no downloadable release asset found for the current platform",
     );
     return;
   }
 
-  const releaseFile = getDownloadfileName();
-  const ghReleaseUri: string = `https://github.com/tomoyanonymous/mimium-rs/releases/download/${mimiumVersion}/${releaseFile}`;
+  const mimiumVersion: string = releaseDownload.release.tag_name;
+  const releaseFile = releaseDownload.asset.name;
+  const ghReleaseUri = releaseDownload.asset.browser_download_url;
 
   const defaultDownloadDir = vscode.Uri.file(getDefaultDownloadPath()).fsPath;
   if (!fs.existsSync(defaultDownloadDir)) {
-    fs.mkdirSync(defaultDownloadDir);
+    fs.mkdirSync(defaultDownloadDir, { recursive: true });
   }
   // now, actually download the thing
   const downloader = new DownloaderHelper(ghReleaseUri, defaultDownloadDir, {});
-  downloader.on("end", (value) => {
-    const res = spawnSync("tar", ["-xf", releaseFile], {
+  downloader.on("end", () => {
+    const extractDir = fs.mkdtempSync(
+      path.join(defaultDownloadDir, ".extract-"),
+    );
+    const res = spawnSync("tar", ["-xf", releaseFile, "-C", extractDir], {
       cwd: defaultDownloadDir,
     });
 
     if (res.error) {
       vscode.window.showErrorMessage(res.error.message);
+      fs.rmSync(extractDir, { recursive: true, force: true });
+      return;
     }
+    if (res.status !== 0) {
+      vscode.window.showErrorMessage(
+        res.stderr.toString() || "mimium: failed to extract downloaded archive",
+      );
+      fs.rmSync(extractDir, { recursive: true, force: true });
+      return;
+    }
+
+    moveExtractedEntries(extractDir, defaultDownloadDir);
+    fs.rmSync(extractDir, { recursive: true, force: true });
     fs.rmSync(path.join(defaultDownloadDir, releaseFile), {
       force: true,
     });
@@ -154,10 +357,10 @@ export const downloadBinary = async () => {
           message: "Downloading the latest version of mimium...",
           increment: incr,
         });
-        if (token.isCancellationRequested){
-          await downloader.stop()
-        }
-      }
+        token.onCancellationRequested(() => {
+          void downloader.stop();
+        });
+      },
     );
   });
 

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -7,5 +7,19 @@ suite("parse version string", () => {
     assert.equal(2, v.major);
     assert.equal(0, v.minor);
     assert.equal(1, v.patch);
+    assert.equal("alpha", v.prerelease);
+  });
+
+  test("stable is newer than prerelease with same core version", () => {
+    const stable = parseVersion("v4.0.0");
+    const alpha = parseVersion("v4.0.0-alpha.7");
+    assert.equal(true, stable.isNewer(alpha));
+    assert.equal(false, alpha.isNewer(stable));
+  });
+
+  test("later prerelease identifier is newer", () => {
+    const older = parseVersion("v4.0.0-alpha.6");
+    const newer = parseVersion("v4.0.0-alpha.7");
+    assert.equal(true, newer.isNewer(older));
   });
 });

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -2,12 +2,60 @@ interface Comparable<T> {
     isNewer(base: T): boolean;
   }
 
+const comparePrereleaseIdentifiers = (
+  left: string,
+  right: string,
+): number => {
+  const leftIsNumber = /^\d+$/.test(left);
+  const rightIsNumber = /^\d+$/.test(right);
+
+  if (leftIsNumber && rightIsNumber) {
+    return parseInt(left, 10) - parseInt(right, 10);
+  }
+  if (leftIsNumber) {
+    return -1;
+  }
+  if (rightIsNumber) {
+    return 1;
+  }
+  return left.localeCompare(right);
+};
+
+const comparePrerelease = (left?: string, right?: string): number => {
+  if (left === undefined && right === undefined) {
+    return 0;
+  }
+  if (left === undefined) {
+    return 1;
+  }
+  if (right === undefined) {
+    return -1;
+  }
+
+  const leftParts = left.split(".");
+  const rightParts = right.split(".");
+  const sharedLength = Math.min(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < sharedLength; index++) {
+    const compared = comparePrereleaseIdentifiers(
+      leftParts[index],
+      rightParts[index],
+    );
+    if (compared !== 0) {
+      return compared;
+    }
+  }
+
+  return leftParts.length - rightParts.length;
+};
+
 /** Comparable Version class. **/
 export class Version implements Comparable<Version> {
     text: string;
     major: number;
     minor: number;
     patch: number;
+    prerelease?: string;
     /**
      * Constructs version from raw text.
      * @param {string} vstring raw version text. should be like "v0.2.45".
@@ -15,7 +63,7 @@ export class Version implements Comparable<Version> {
      */
     constructor(vstring: string) {
       this.text = vstring;
-      const matchedv = vstring.match(/v?([0-9]+)\.([0-9]+)\.([0-9]+)(-.*)?/);
+      const matchedv = vstring.match(/v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z.-]+))?/);
       if (matchedv === null) {
         console.error("invalid version format");
         this.major = 0;
@@ -34,7 +82,7 @@ export class Version implements Comparable<Version> {
       this.minor = parseInt(matchedv[2]);
       this.patch = parseInt(matchedv[3]);
       if (matchedv[4]) {
-        console.warn("alpha version is ignored.");
+        this.prerelease = matchedv[4];
       }
     }
     /**
@@ -48,7 +96,10 @@ export class Version implements Comparable<Version> {
       if (this.minor != base.minor) {
         return this.minor > base.minor;
       }
-      return this.patch > base.patch;
+      if (this.patch != base.patch) {
+        return this.patch > base.patch;
+      }
+      return comparePrerelease(this.prerelease, base.prerelease) > 0;
     }
   }
   

--- a/package.json
+++ b/package.json
@@ -70,6 +70,15 @@
           "type": "boolean",
           "default": true,
           "description": "Check if the latest version of mimium is available on startup"
+        },
+        "mimium.releaseChannel": {
+          "type": "string",
+          "enum": [
+            "stable",
+            "alpha"
+          ],
+          "default": "stable",
+          "markdownDescription": "Select which mimium-rs release channel to download. `stable` only downloads non-prerelease versions, while `alpha` allows the latest alpha builds."
         }
       }
     },


### PR DESCRIPTION
fix #13.

This PR adds 1 feature and 1 fix.

Since v4.0.0-alpha7, publishing workflow has been changed and release URL has also changed.

Now the extension tries to search specific architecture string from release URL. 

Also, alpha release should not be included for the most of users so I added extension config to select download channel. 

